### PR TITLE
Fix leading whitespace causing problems

### DIFF
--- a/lib/app_query/tokenizer.rb
+++ b/lib/app_query/tokenizer.rb
@@ -95,8 +95,9 @@ module AppQuery
       if eos?
         emit_token "COMMA", v: ","
         emit_token "WHITESPACE", v: "\n"
+      elsif match?(/\s/)
+        push_return :lex_prepend_cte, :lex_whitespace
       else
-        # emit_token "WHITESPACE", v: " "
         push_return :lex_prepend_cte, :lex_recursive_cte
       end
     end


### PR DESCRIPTION
irb(main):124" AppQuery("select 1").prepend_cte(<<-CTE) irb(main):125"  foo as (values(1))
irb(main):126> CTE
💥