### PR TITLE
Support unpaginated

### DIFF
--- a/examples/demo/queries/recent_articles.sql.erb
+++ b/examples/demo/queries/recent_articles.sql.erb
@@ -53,6 +53,4 @@ WHERE EXISTS (
 )
 GROUP BY recent_articles.article_id
 ORDER BY recent_articles.article_published_on desc
-<% if @page %>
-<%= paginate(page:, per_page:) %>
-<% end %>
+<%= paginate(page:, per_page:) -%>

--- a/lib/app_query.rb
+++ b/lib/app_query.rb
@@ -772,8 +772,9 @@ module AppQuery
       # Replace :_ with the current CTE name
       processed_sql = sql.gsub(/:_\b/, current_cte)
 
-      # Wrap current SELECT in numbered CTE
-      new_cte = "#{current_cte} AS (\n  #{select}\n)"
+      # Wrap current SELECT in numbered CTE (indent all lines, strip trailing whitespace)
+      indented_select = select.rstrip.gsub("\n", "\n  ")
+      new_cte = "#{current_cte} AS (\n  #{indented_select}\n)"
 
       append_cte(new_cte).then do |q|
         # Replace the SELECT token with processed_sql and increment depth

--- a/lib/app_query/paginatable.rb
+++ b/lib/app_query/paginatable.rb
@@ -125,6 +125,12 @@ module AppQuery
       self
     end
 
+    def unpaginated
+      @page = nil
+      @per_page = nil
+      self
+    end
+
     def entries
       @_entries ||= build_paginated_result(super)
     end
@@ -135,7 +141,7 @@ module AppQuery
 
     def unpaginated_query
       base_query
-        .render(**render_vars.except(:page, :per_page))
+        .render(**render_vars, page: nil)
         .with_binds(**bind_vars)
     end
 

--- a/lib/app_query/render_helpers.rb
+++ b/lib/app_query/render_helpers.rb
@@ -214,6 +214,7 @@ module AppQuery
     #
     # @raise [ArgumentError] if page or per_page is not a positive integer
     def paginate(page:, per_page:)
+      return "" if page.nil?
       raise ArgumentError, "page must be a positive integer (got #{page.inspect})" unless page.is_a?(Integer) && page > 0
       raise ArgumentError, "per_page must be a positive integer (got #{per_page.inspect})" unless per_page.is_a?(Integer) && per_page > 0
 

--- a/lib/app_query/tokenizer.rb
+++ b/lib/app_query/tokenizer.rb
@@ -104,7 +104,7 @@ module AppQuery
 
     def lex_append_cte
       emit_token "COMMA", v: ","
-      emit_token "WHITESPACE", v: "\n  "
+      emit_token "WHITESPACE", v: "\n"
       push_return :lex_recursive_cte
     end
 

--- a/spec/app_query/q_spec.rb
+++ b/spec/app_query/q_spec.rb
@@ -300,6 +300,10 @@ RSpec.describe AppQuery::Q do
         SQL
       end
 
+      it "returns empty string when page is nil" do
+        expect(render_sql("<%= paginate(page: nil, per_page: 25) %>", {})).to eq("")
+      end
+
       it "raises for invalid page" do
         expect {
           render_sql("<%= paginate(page: 0, per_page: 25) %>", {})


### PR DESCRIPTION
paginate erb helper now skips pagination when page: nil.

This is helpful when having a `FooQuery.build` that contains pagination by default - then `query.unpaginated` removes the pagination for non-default situations.